### PR TITLE
feature: add support for custom localtuya integration title.

### DIFF
--- a/pyscript/sync_tuya_keys.py
+++ b/pyscript/sync_tuya_keys.py
@@ -8,6 +8,8 @@ from tuya.exceptions import InvalidAuthentication
 
 @service
 def syncTuyaKeys():
+    # set `localtuya_title` to your LocalTuya integration title
+    localtuya_title = 'localtuya'
     api = TuyaAPI("[REPLACE_WITH_USERNAME]", "[REPLACE_WITH_PASSWORD]")
     await hass.async_add_executor_job(api.login)
     groups = await hass.async_add_executor_job(api.groups);
@@ -19,15 +21,18 @@ def syncTuyaKeys():
             localKeys[dev.id] = dev.localKey;
 
     ## update config
-    for entryId in hass.config_entries._entries:
-        entry = hass.config_entries.async_get_entry(entryId)
-        if (entry.title == 'localtuya'):
-            for devId in entry.data['devices'].keys():
-                localKey = entry.data['devices'][devId]['local_key']
-                if (devId in localKeys and localKeys[devId] != localKey):
-                    log.info('[New] \tdevId: ' + devId + ', localkey: ' + localKey + ' -> ' + localKeys[devId])
-                    new = {**entry.data}
-                    new['devices'][devId]['local_key'] = localKeys[devId]
-                    hass.config_entries.async_update_entry(entry, data=new)
-                #else:
-                #    log.info('[Unchanged]\t devId: ' + devId + ', localkey: ' + localKey)
+    entries = {entry: entry.title for entry in hass.config_entries.async_entries()}
+    entry = [key for key, value in entries.items() if value == localtuya_title]
+    if entry:
+        entry = entry[0]
+        for devId in entry.data['devices'].keys():
+            localKey = entry.data['devices'][devId]['local_key']
+            if (devId in localKeys and localKeys[devId] != localKey):
+                log.info('[New] \tdevId: ' + devId + ', localkey: ' + localKey + ' -> ' + localKeys[devId])
+                new = {**entry.data}
+                new['devices'][devId]['local_key'] = localKeys[devId]
+                hass.config_entries.async_update_entry(entry, data=new)
+            else:
+                log.info('[Unchanged]\t devId: ' + devId + ', localkey: ' + localKey)
+    else:
+        log.info(f"{localtuya_title} title not found in config. Check the title of your localtuya integration.")


### PR DESCRIPTION
Title is user configurable field in Home Assistant. In some cases, when the user changes LocalTuya integration title the pyscript service will break without properly logging the problem. This patch will add configurable title and will display descriptive error in cases where localtuya integration title is not found.